### PR TITLE
Modernization changes

### DIFF
--- a/Core/Keychain.swift
+++ b/Core/Keychain.swift
@@ -67,8 +67,8 @@ struct Keychain {
                 kSecClass as String: kSecClassGenericPassword,
                 kSecAttrService as String: secureDateProviderService,
                 kSecMatchLimit as String: kSecMatchLimitOne,
-                kSecReturnAttributes as String: kCFBooleanTrue,
-                kSecReturnData as String: kCFBooleanTrue
+				kSecReturnAttributes as String: kCFBooleanTrue ?? "true",
+                kSecReturnData as String: kCFBooleanTrue ?? "true"
             ]
 
             var queryResult: AnyObject?

--- a/Core/Product Request/PaymentTransactionObserver.swift
+++ b/Core/Product Request/PaymentTransactionObserver.swift
@@ -74,7 +74,9 @@ public class PaymentTransactionObserver: NSObject, SKPaymentTransactionObserver 
                 
             case .deferred, .purchasing:
                 break
-            }
+			@unknown default:
+				break
+			}
         }
     }
     

--- a/Core/Store.swift
+++ b/Core/Store.swift
@@ -254,7 +254,7 @@ extension Store {
     fileprivate func configureSecureDateProviderRefresh() {
         secureDateProviderRefreshIfNotPurchased()
 
-        observers.append(NotificationCenter.when(.UIApplicationWillEnterForeground) { [weak self] _ in
+        observers.append(NotificationCenter.when(UIApplication.willEnterForegroundNotification) { [weak self] _ in
             self?.secureDateProviderRefreshIfNotPurchased()
         })
         

--- a/IAP.xcodeproj/project.pbxproj
+++ b/IAP.xcodeproj/project.pbxproj
@@ -782,6 +782,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 7F5C9E1E1F51F37E002B41B4;
 			productRefGroup = 7F5C9E2B1F51F3AC002B41B4 /* Products */;

--- a/IAP.xcodeproj/project.pbxproj
+++ b/IAP.xcodeproj/project.pbxproj
@@ -762,7 +762,7 @@
 				TargetAttributes = {
 					7F5C9E291F51F3AC002B41B4 = {
 						CreatedOnToolsVersion = 9.0;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1020;
 					};
 					7F5C9E321F51F3AC002B41B4 = {
 						CreatedOnToolsVersion = 9.0;
@@ -1062,7 +1062,7 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/iOS/OpenSSL/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -1137,7 +1137,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/iOS/OpenSSL/**";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";

--- a/IAP.xcodeproj/xcshareddata/xcschemes/IAP-iOS.xcscheme
+++ b/IAP.xcodeproj/xcshareddata/xcschemes/IAP-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0940"
+   LastUpgradeVersion = "1100"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F5C9E291F51F3AC002B41B4"
+            BuildableName = "IAP.framework"
+            BlueprintName = "IAP-iOS"
+            ReferencedContainer = "container:IAP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -39,17 +48,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7F5C9E291F51F3AC002B41B4"
-            BuildableName = "IAP.framework"
-            BlueprintName = "IAP-iOS"
-            ReferencedContainer = "container:IAP.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -70,8 +68,6 @@
             ReferencedContainer = "container:IAP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/IAP.xcodeproj/xcshareddata/xcschemes/IAP-iOS.xcscheme
+++ b/IAP.xcodeproj/xcshareddata/xcschemes/IAP-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1100"
+   LastUpgradeVersion = "1020"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "7F5C9E291F51F3AC002B41B4"
-            BuildableName = "IAP.framework"
-            BlueprintName = "IAP-iOS"
-            ReferencedContainer = "container:IAP.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,6 +39,17 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "7F5C9E291F51F3AC002B41B4"
+            BuildableName = "IAP.framework"
+            BlueprintName = "IAP-iOS"
+            ReferencedContainer = "container:IAP.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -68,6 +70,8 @@
             ReferencedContainer = "container:IAP.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/iOS/Source/Extensions/UIApplication.swift
+++ b/iOS/Source/Extensions/UIApplication.swift
@@ -69,10 +69,10 @@ extension UIApplication {
         // Use the status bar orientation as it has proven to be a more reliable way to get the orientation for this purpose.
         // Using UIDevice orientation won't work if the device is in face up for face down orientation.
         let orientation = UIApplication.shared.statusBarOrientation
-        if UIInterfaceOrientationIsLandscape(orientation) {
+        if orientation.isLandscape {
             return true
         }
-        else if UIInterfaceOrientationIsPortrait(orientation) {
+        else if orientation.isPortrait {
             return false
         }
         else {
@@ -114,7 +114,7 @@ extension UIApplication {
     }
 }
 
-extension Dictionary where Key == UIApplicationLaunchOptionsKey {
+extension Dictionary where Key == UIApplication.LaunchOptionsKey {
     var url: URL? {
         return self[.url] as? URL
     }    

--- a/iOS/Source/Extensions/UIImage.swift
+++ b/iOS/Source/Extensions/UIImage.swift
@@ -26,7 +26,7 @@
 import UIKit
 
 public extension UIImage {
-    public convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
+    convenience init?(color: UIColor, size: CGSize = CGSize(width: 1, height: 1)) {
         let rect = CGRect(origin: .zero, size: size)
         UIGraphicsBeginImageContextWithOptions(rect.size, false, 0.0)
         color.setFill()

--- a/iOS/Source/IAPDialogCell.swift
+++ b/iOS/Source/IAPDialogCell.swift
@@ -127,10 +127,10 @@ extension IAPDialogCell {
         
         let textSize = CGSize(width: cellWidth - (IAPDialogCell.textSidePadding * 2), height: CGFloat.greatestFiniteMagnitude)
         
-        let title = NSAttributedString(string: product.skProduct.localizedTitle, attributes: [NSAttributedStringKey.font: UIFont.titleFont])
+        let title = NSAttributedString(string: product.skProduct.localizedTitle, attributes: [NSAttributedString.Key.font: UIFont.titleFont])
         let titleHeight = ceil(title.boundingRect(with: textSize, options: [.usesFontLeading, .usesLineFragmentOrigin], context: nil).height)
         
-        let description = NSAttributedString(string: product.marketingMessage, attributes: [NSAttributedStringKey.font: UIFont.descriptionFont])
+        let description = NSAttributedString(string: product.marketingMessage, attributes: [NSAttributedString.Key.font: UIFont.descriptionFont])
         let descriptionHeight = ceil(description.boundingRect(with: textSize, options: [.usesFontLeading, .usesLineFragmentOrigin], context: nil).height)
         
         guard isCompact else {
@@ -138,7 +138,7 @@ extension IAPDialogCell {
             return CGSize(width: cellWidth, height: cellHeight)
         }
         
-        let price = NSAttributedString(string: product.skProduct.price.stringValue, attributes: [NSAttributedStringKey.font: UIFont.priceFont])
+        let price = NSAttributedString(string: product.skProduct.price.stringValue, attributes: [NSAttributedString.Key.font: UIFont.priceFont])
         let priceHeight = ceil(price.boundingRect(with: textSize, options: [.usesFontLeading, .usesLineFragmentOrigin], context: nil).height)
         
         let cellHeight = IAPDialogCell.titleTopPaddingRegular + titleHeight + IAPDialogCell.titleStackViewSpacingCompact + priceHeight + IAPDialogCell.descriptionToPricePaddingCompact + descriptionHeight + IAPDialogCell.descriptionBottomPaddingCompact


### PR DESCRIPTION
## Objective

Updates for Xcode 10/iOS 12/Swift 5

## Description

Fixed deprecation errors and warnings

## How to Test

Project builds with Xcode 10

## Merge Checklist

Can't test. IAP/App store does not work in the simulator. To run the example app on a device, I must change the bundle identifier (pending new developer accounts), which means the IAP items do not load.

- [ ] iOS Example app target builds and runs
- [ ] iOS Example tested on iPad 1/3 Split Screen
- [ ] iOS Example tested on iPad 1/2 Split Screen
- [ ] iOS Example tested on iPad 2/3 Split Screen
- [ ] iOS Example tested on iPhone 5
- [ ] iOS Example tested on iPhone 8+
- [ ] iOS Example tested on iPhone X
