### PR TITLE
Update modal presentation style

### DIFF
--- a/Core/Store.swift
+++ b/Core/Store.swift
@@ -150,6 +150,16 @@ public class Store<Product: Purchaseable> {
         
         self.modalViewController = modalViewController
         
+        // Determine how to present the view controller based on the horizontal size class
+        switch presentingViewController.traitCollection.horizontalSizeClass {
+        case .compact:
+            self.modalViewController?.modalPresentationStyle = .fullScreen
+        case .regular:
+            self.modalViewController?.modalPresentationStyle = .formSheet
+        default:
+            self.modalViewController?.modalPresentationStyle = .fullScreen
+        }
+        
         presentingViewController.present(modalViewController, animated: true) { [weak self] in
             self?.refreshProductsList()
         }


### PR DESCRIPTION
## Objective

iOS 13 changed the default modal presentation style. IAPKit was designed with the pre-iOS 13 defaults.

## Description

It is pretty easy to restore the pre iOS 13 behavior by forking the presentation logic based on horizontal size class.
